### PR TITLE
Improve doc comment for read_game

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -559,7 +559,7 @@ impl<R: Read> BufferedReader<R> {
     }
 
     /// Read a single game, if any, and returns the result produced by the
-    /// visitor.
+    /// visitor. Returns Ok(None) if the underlying reader is empty.
     ///
     /// # Errors
     ///


### PR DESCRIPTION
Thank you for a really useful library.

This is a small addition to BufferedReader::read_game()'s doc comment. I expected it to return Err on empty input, and it took me ages to figure out why it kept succeeding. Hopefully nobody else will make this mistake in the future.