### PR TITLE
Add has_more() to BufferedReader.

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -607,6 +607,18 @@ impl<R: Read> BufferedReader<R> {
     pub fn into_inner(self) -> Chain<Cursor<Buffer>, R> {
         Cursor::new(self.buffer).chain(self.inner)
     }
+
+    /// Returns whether the reader has another game to parse, but does not
+    /// actually parse it.
+    ///
+    /// # Errors
+    ///
+    /// * I/O error from the underlying reader.
+    pub fn has_more(&mut self) -> io::Result<bool> {
+        self.skip_bom()?;
+        self.skip_whitespace()?;
+        Ok(self.fill_buffer_and_peek()?.is_some())
+    }
 }
 
 impl<R: Read> ReadPgn for BufferedReader<R> {


### PR DESCRIPTION
For a project I'm working on it'd be useful to query a reader if it has another game without actually parsing it, as sketched in this PR.

My use-case is that I want to parse _exactly_ one game from the input and emit a warning if there's data after the first `.read_game()` returns. In this case, I'd rather just check for the presence of more data than actually parse the data.