### PR TITLE
Roundtrip for `BufferedReader::into_inner`

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,5 +1,7 @@
-use std::cmp;
-use std::io::{self, Read};
+use std::{
+    cmp,
+    io::{self, Read},
+};
 
 #[derive(Debug, Clone)]
 pub struct Buffer {


### PR DESCRIPTION
Adds `BufferedReader::from_buffer`, allowing users to go from `BufferedReader::into_inner` back to a `BufferedReader` of the same type. The documentation has an example which also acts as a test.